### PR TITLE
Added a config option to always run in verbose mode

### DIFF
--- a/lib/kaiser/cli.rb
+++ b/lib/kaiser/cli.rb
@@ -53,24 +53,23 @@ module Kaiser
       # easily use ARGV.shift to access its own subcommands.
       ARGV.shift
 
+      Kaiser::Config.load(Dir.pwd)
+
       # We do all this work in here instead of the exe/kaiser file because we
       # want -h options to output before we check if a Kaiserfile exists.
       # If we do it in exe/kaiser, people won't be able to check help messages
       # unless they create a Kaiserfile firest.
-      out = Kaiser::Dotter.new
-      info_out = Kaiser::AfterDotter.new(dotter: out)
       if opts[:quiet]
-        out = File.open(File::NULL, 'w')
-        info_out = File.open(File::NULL, 'w')
-      elsif opts[:verbose]
-        out = $stderr
+        Config.out = File.open(File::NULL, 'w')
+        Config.info_out = File.open(File::NULL, 'w')
+      elsif opts[:verbose] || Config.always_verbose?
+        Config.out = $stderr
+        Config.info_out = Kaiser::AfterDotter.new(dotter: Kaiser::Dotter.new)
+      else
+        Config.out = Kaiser::Dotter.new
+        Config.info_out = Kaiser::AfterDotter.new(dotter: Config.out)
       end
 
-      Kaiser::Config.load(
-        `pwd`.chomp,
-        debug_output: out,
-        info_output: info_out
-      )
       cmd.set_config
 
       cmd.execute(opts)

--- a/lib/kaiser/config.rb
+++ b/lib/kaiser/config.rb
@@ -11,7 +11,10 @@ module Kaiser
                   :out,
                   :info_out
 
-      def load(work_dir, debug_output:, info_output:)
+      attr_writer :out,
+                  :info_out
+
+      def load(work_dir)
         @work_dir = work_dir
         @config_dir = "#{ENV['HOME']}/.kaiser"
 
@@ -30,12 +33,15 @@ module Kaiser
             dns: 'kaiser-dns',
             certs: 'kaiser-certs'
           },
-          largest_port: 9000
+          largest_port: 9000,
+          always_verbose: false
         }
 
-        @out = debug_output
-        @info_out = info_output
         load_config
+      end
+
+      def always_verbose?
+        @config[:always_verbose]
       end
 
       def load_config

--- a/lib/kaiser/version.rb
+++ b/lib/kaiser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kaiser
-  VERSION = '0.4.2'
+  VERSION = '0.4.3'
 end


### PR DESCRIPTION
After using Kaiser for a while I found that I never really want to run it without the `-v` flag. I kept forgetting to include it and then having to run commands again when something went wrong so quickly put in a config option in `~/.kaiser/.config` to always run in verbose mode.