### PR TITLE
Don't namespace containers on branch

### DIFF
--- a/lib/kaiser/cmds/db_load.rb
+++ b/lib/kaiser/cmds/db_load.rb
@@ -11,7 +11,7 @@ module Kaiser
 
           Alternatively you can also load it from your current directory.
 
-          If no database name was provided, the default database stored at \`~/.kaiser/<ENV_NAME>/<current_github_branch_name>/.default.tar.bz\` will be used.
+          If no database name was provided, the default database stored at \`~/.kaiser/<ENV_NAME>/<current_github_branch_name>/default.tar.bz\` will be used.
 
           USAGE: kaiser db_load
                  kaiser db_load DB_BACKUP_FILENAME
@@ -21,7 +21,7 @@ module Kaiser
 
       def execute(opts)
         ensure_setup
-        name = ARGV.shift || '.default'
+        name = ARGV.shift || DEFAULT_DB_FILE
         load_db(name)
       end
     end

--- a/lib/kaiser/cmds/db_reset.rb
+++ b/lib/kaiser/cmds/db_reset.rb
@@ -5,7 +5,7 @@ module Kaiser
     class DbReset < Cli
       def usage
         <<~EOS
-          Shuts down the database docker container, *replaces* the database with the default database image stored at \`~/.kaiser/<ENV_NAME>/<current_github_branch_name>/.default.tar.bz\` and brings the container up again.
+          Shuts down the database docker container, *replaces* the database with the default database image stored at \`~/.kaiser/<ENV_NAME>/<current_github_branch_name>/default.tar.bz\` and brings the container up again.
 
           This is the same as running \`kaiser db_load\` with no arguments.
 
@@ -15,7 +15,7 @@ module Kaiser
 
       def execute(opts)
         ensure_setup
-        load_db('.default')
+        load_db(DEFAULT_DB_FILE)
       end
     end
   end

--- a/lib/kaiser/cmds/db_save.rb
+++ b/lib/kaiser/cmds/db_save.rb
@@ -18,7 +18,7 @@ module Kaiser
 
       def execute(opts)
         ensure_setup
-        name = ARGV.shift || '.default'
+        name = ARGV.shift || DEFAULT_DB_FILE
         save_db(name)
       end
     end

--- a/lib/kaiser/cmds/up.rb
+++ b/lib/kaiser/cmds/up.rb
@@ -9,7 +9,7 @@ module Kaiser
         <<~EOS
           Boots up the application in docker as defined in the \`Kaiserfile\` in its source code. Usually this will create two docker containers \`<ENV_NAME>-db\` and \`<ENV_NAME>-app\` running your database and application respectively.
 
-          A backup of the default database is created and saved to \`~/.kaiser/<ENV_NAME>/<current_github_branch_name>/.default.tar.bz\`. This can be restored at any time using the \`db_reset\` command.
+          A backup of the default database is created and saved to \`~/.kaiser/<ENV_NAME>/<current_github_branch_name>/default.tar.bz\`. This can be restored at any time using the \`db_reset\` command.
 
           USAGE: kaiser up
         EOS
@@ -32,7 +32,7 @@ module Kaiser
         File.write(tmp_dockerfile_name, docker_file_contents)
         build_args = docker_build_args.map { |k, v| "--build-arg #{k}=#{v}" }
         CommandRunner.run! Config.out, "docker build
-          -t kaiser:#{envname}-#{current_branch}
+          -t kaiser:#{envname}
           -f #{tmp_dockerfile_name} #{Config.work_dir}
           #{build_args.join(' ')}"
         FileUtils.rm(tmp_dockerfile_name)


### PR DESCRIPTION
Right now, container version names are `<project>-<branch>`. After this PR, they are just `<project>` (despite this branch including the word "optional"). This means you don't have to re-build every time you switch branches.

I don't know if this change is something we actually want to merge in, but I've been using it for awhile and it has only sped me up. Whenever my schema gets messed up by running migrations in different branches (rarely happens), I just reset the DB.