### PR TITLE
Sync a .profile for use with bash/sh

### DIFF
--- a/lib/kaiser/cli.rb
+++ b/lib/kaiser/cli.rb
@@ -215,9 +215,9 @@ module Kaiser
     def default_volumes
       volumes = []
 
-      if File.exist?(Config.host_shell_rc)
-        volumes << "-v #{Config.host_shell_rc}:#{Config.container_shell_rc}"
-      end
+      return [] unless File.exist?(Config.host_shell_rc)
+
+      volumes << "-v #{Config.host_shell_rc}:#{Config.container_shell_rc}"
 
       volumes.join(' ')
     end

--- a/lib/kaiser/config.rb
+++ b/lib/kaiser/config.rb
@@ -56,7 +56,7 @@ module Kaiser
       end
 
       def container_shell_rc
-        kaiserfile.shell_rc_path
+        kaiserfile.shell_rc
       end
 
       def load_config

--- a/lib/kaiser/config.rb
+++ b/lib/kaiser/config.rb
@@ -34,14 +34,29 @@ module Kaiser
             certs: 'kaiser-certs'
           },
           largest_port: 9000,
-          always_verbose: false
+          always_verbose: false,
+          host_shell_rc: "#{ENV['HOME']}/.kaiser_profile",
+          always_login_shell: true
         }
 
         load_config
+        initialize_kaiser_profile
       end
 
       def always_verbose?
         @config[:always_verbose]
+      end
+
+      def always_login_shell?
+        @config[:always_login_shell]
+      end
+
+      def host_shell_rc
+        @config[:host_shell_rc]
+      end
+
+      def container_shell_rc
+        kaiserfile.shell_rc_path
       end
 
       def load_config
@@ -55,6 +70,13 @@ module Kaiser
           **(loaded || {}),
           shared_names: { **(config_shared_names || {}), **(loaded_shared_names || {}) }
         }
+      end
+
+      def initialize_kaiser_profile
+        return if File.exist?(host_shell_rc)
+
+        default_shell_rc = File.join(__dir__, 'files', 'default_kaiser_profile.bash')
+        FileUtils.cp default_shell_rc, host_shell_rc
       end
     end
   end

--- a/lib/kaiser/files/default_kaiser_profile.bash
+++ b/lib/kaiser/files/default_kaiser_profile.bash
@@ -1,0 +1,19 @@
+# If not running interactively, don't do anything
+[[ $- != *i* ]] && return
+
+# ls colors
+alias ls='ls --color=auto'
+
+# Nice PS1 colors
+color1="\[\e[38;5;94m\]"
+color2="\[\e[38;5;96m\]"
+color3="\[\e[38;5;98m\]"
+color4="\[\e[38;5;135m\]"
+color5="\[\e[38;5;170m\]"
+bracecolor="\[\e[38;5;108m\]"
+dollarcolor="\[\e[38;5;108m\]"
+endcolor="\[\e[m\]"
+PS1="$bracecolor[$color1\u$color2@${color3}kaiser:${color4}${KAISER_NAME} $color5\W$endcolor$bracecolor]$dollarcolor\\$\[\e[m\] "
+
+# Vim input (if you want it)
+#set -o vi

--- a/lib/kaiser/kaiserfile.rb
+++ b/lib/kaiser/kaiserfile.rb
@@ -10,11 +10,13 @@ module Kaiser
                   :params,
                   :database_reset_command,
                   :attach_mounts,
+                  :shell_rc,
                   :server_type
 
     def initialize(filename)
       Optimist.die 'No Kaiserfile in current directory' unless File.exist? filename
 
+      @shell_rc = '~/.profile'
       @databases = {}
       @attach_mounts = []
       @server_type = :unknown
@@ -28,6 +30,23 @@ module Kaiser
 
     def attach_mount(from, to)
       attach_mounts << [from, to]
+    end
+
+    def container_workdir
+      docker_file_contents.each_line do |line|
+        if /WORKDIR (?<workdir>[^\s]+)/ =~ line
+          return workdir
+        end
+      end
+      nil
+    end
+
+    def shell_rc_path
+      shell_rc.gsub('~', container_workdir)
+    end
+
+    def container_shell_rc(value)
+      self.shell_rc = value
     end
 
     def db(image,

--- a/lib/kaiser/kaiserfile.rb
+++ b/lib/kaiser/kaiserfile.rb
@@ -16,7 +16,7 @@ module Kaiser
     def initialize(filename)
       Optimist.die 'No Kaiserfile in current directory' unless File.exist? filename
 
-      @shell_rc = '~/.profile'
+      @shell_rc = '/etc/profile'
       @databases = {}
       @attach_mounts = []
       @server_type = :unknown
@@ -30,19 +30,6 @@ module Kaiser
 
     def attach_mount(from, to)
       attach_mounts << [from, to]
-    end
-
-    def container_workdir
-      docker_file_contents.each_line do |line|
-        if /WORKDIR (?<workdir>[^\s]+)/ =~ line
-          return workdir
-        end
-      end
-      nil
-    end
-
-    def shell_rc_path
-      shell_rc.gsub('~', container_workdir)
     end
 
     def container_shell_rc(value)


### PR DESCRIPTION
I spend most of my dev time in `kaiser up -a bash` where the shell is pretty boring. This lets me write a `~/.kaiser_profile` that gets loaded into my running containers as `.profile` (configurable).

![Screenshot from 2020-01-10 15-51-27](https://user-images.githubusercontent.com/2793160/72131946-14451d80-33c1-11ea-9489-0f5987a4bceb.png)

The colors are great, but really I just didn't want to keep typing `set -a vi` every time I hop into a Kaiser container.