### PR TITLE
Allow gem to be pushed to rubygems

### DIFF
--- a/kaiser.gemspec
+++ b/kaiser.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   # 'allowed_push_host' to allow pushing to a single host or delete this section
   # to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = 'https://gems.labs.degica.com'
+    spec.metadata['allowed_push_host'] = 'https://rubygems.org'
   else
     raise 'RubyGems 2.0 or newer is required to protect against ' \
       'public gem pushes.'


### PR DESCRIPTION
Now that we control the rubygem we should allow gem publishing
https://rubygems.org/gems/kaiser