### PR TITLE
Add some kaiserfile defaults for easier use

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -30,7 +30,7 @@ Metrics/BlockLength:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 430
+  Max: 431
 
 # Offense count: 2
 Metrics/CyclomaticComplexity:

--- a/README.md
+++ b/README.md
@@ -97,6 +97,33 @@ open http://myapp.lvh.me
 
 And enjoy previewing your app!
 
+#### Anatomy of a Kaiserfile
+
+A Kaiserfile is made up of statements, which are different commands followed by some parameters. Each command is just a ruby method so you can call it that way. Only the `dockerfile` command is required. All the other commands are either not required or have defaults.
+
+- `plugin` - Takes 1 parameter: the name of the plugin you wish to use in this Kaiserfile.
+- `dockerfile` - This command is always required. Takes 1 parameter: the name of the Dockerfile you want to use with this Kaiserfile. You only need to use this command once. Using it multiple times will simply cause the last command to be used.
+- `attach_mount` - Takes 2 parameters: The first parameter is the relative path of a folder or a file outside the container and the second parameter is its absolute path inside the container. This is only used when `kaiser attach` or `kaiser up -a` is used. This will mount the file or folder inside the container and sync their contents. If the file you specified does not exist, Kaiser will create a folder where you specify it and then mount that folder inside the container.
+- `expose` - Takes 1 parameter: The port of the server running inside the container. This port is not exposed on the host, so it will not occupy a port on the computer you run kaiser on. Instead, Kaiser will select a random port on the host computer to forward traffic to and from.
+- `app_params` - Takes 1 parameter: A string of parameters to the `docker run` command to add custom environment variables with. Please refer to the docker documentation to see what kinds of parameters you can pass to the `docker run` command. By default this is just an empty string.
+- `type` - Takes 1 parameter: Right now the only parameter it can take is `:http`. If this parameter is specified, kaiser will poll the application until it receives a 200 status code before it closes when you use `kaiser up` If it doesn't it will close with a status code of 1.
+- `db_reset_command` - Takes 1 parameter: A command to reset the database. This command is optional. By default this parameter is `echo "no db to reset"`
+- `db` - Takes 1 parameter in the form of a hash. The default value of the hash is as follows:
+
+```
+{
+  image: 'alpine',
+  port: 1234,
+  data_dir: '/tmp/data',
+  params: '',
+  commands: 'echo "no db"',
+  waitscript: 'echo "no dbwait"',
+  waitscript_params: ''
+}
+```
+
+You can use this to customize the database that you wish to use with your server.
+
 ### Alternative Kaiserfile
 
 If you want change your dev environment for a project, but don't want to overwrite the project's Kaiserfile/Dockerfile,

--- a/lib/kaiser/cli.rb
+++ b/lib/kaiser/cli.rb
@@ -17,6 +17,8 @@ module Kaiser
       @config = Config.config
       @out = Config.out
       @info_out = Config.info_out
+
+      @kaiserfile.validate!
     end
 
     # At first I did this in the constructor but the problem with that is Optimist

--- a/lib/kaiser/kaiserfile.rb
+++ b/lib/kaiser/kaiserfile.rb
@@ -32,6 +32,10 @@ module Kaiser
       instance_eval File.read(filename), filename
     end
 
+    def validate!
+      raise 'No dockerfile specified.' if @docker_file_contents.nil?
+    end
+
     def plugin(name)
       raise "Plugin #{name} is not loaded." unless Plugin.loaded?(name)
 

--- a/lib/kaiser/kaiserfile.rb
+++ b/lib/kaiser/kaiserfile.rb
@@ -14,10 +14,20 @@ module Kaiser
     def initialize(filename)
       Optimist.die 'No Kaiserfile in current directory' unless File.exist? filename
 
-      @databases = {}
+      @database = {
+        image: 'alpine',
+        port: 1234,
+        data_dir: '/tmp/data',
+        params: '',
+        commands: 'echo "no db"',
+        waitscript: 'echo "no dbwait"',
+        waitscript_params: ''
+      }
       @attach_mounts = []
       @params_array = []
       @server_type = :unknown
+      @database_reset_command = 'echo "no db to reset"'
+      @port = 1234
 
       instance_eval File.read(filename), filename
     end

--- a/spec/kaiserfile_spec.rb
+++ b/spec/kaiserfile_spec.rb
@@ -37,6 +37,21 @@ RSpec.describe Kaiser::Kaiserfile do
   end
 
   context '#db' do
+    context 'with no db script' do
+      let(:kaiserfile) { '' }
+
+      it 'sets up the database variable to defaults' do
+        kaiserfile = Kaiser::Kaiserfile.new('Kaiserfile')
+        expect(kaiserfile.database[:image]).to eq 'alpine'
+        expect(kaiserfile.database[:data_dir]).to eq '/tmp/data'
+        expect(kaiserfile.database[:port]).to eq 1234
+        expect(kaiserfile.database[:params]).to eq ''
+        expect(kaiserfile.database[:commands]).to eq 'echo "no db"'
+        expect(kaiserfile.database[:waitscript]).to eq 'echo "no dbwait"'
+        expect(kaiserfile.database[:waitscript_params]).to eq ''
+      end
+    end
+
     context 'with a simple db script' do
       let(:kaiserfile) { <<-KAISERFILE }
         db 'somedb:version',


### PR DESCRIPTION
This PR adds defaults to make a Kaiserfile easier to write by making all the commands optional. Also adds some documentation to the README.

Fixes #56
