### PR TITLE
Dynamically require plugins as needed

### DIFF
--- a/lib/kaiser.rb
+++ b/lib/kaiser.rb
@@ -27,7 +27,6 @@ require 'kaiser/cmds/set'
 require 'kaiser/cmds/root'
 
 require 'kaiser/plugin'
-require 'kaiser/plugins/git_submodule'
 
 # Kaiser
 module Kaiser

--- a/lib/kaiser/kaiserfile.rb
+++ b/lib/kaiser/kaiserfile.rb
@@ -37,6 +37,7 @@ module Kaiser
     end
 
     def plugin(name)
+      require "kaiser/plugins/#{name}"
       raise "Plugin #{name} is not loaded." unless Plugin.loaded?(name)
 
       Plugin.all_plugins[name].new(self).on_init

--- a/lib/kaiser/plugin.rb
+++ b/lib/kaiser/plugin.rb
@@ -56,3 +56,9 @@ module Kaiser
     end
   end
 end
+
+# Little stub to initialize the namespace
+module Kaiser
+  module Plugins
+  end
+end

--- a/spec/plugins/git_submodule_spec.rb
+++ b/spec/plugins/git_submodule_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Kaiser::Plugins::GitSubmodule do
+RSpec.describe 'Kaiser::Plugins::GitSubmodule' do
   let(:kaiserfile) { 'plugin :git_submodule' }
 
   before { setup_dummy_app }


### PR DESCRIPTION
This PR makes it so all plugins are dynamically required at runtime. This makes it easier to add plugins without having to keep adding to the list of requires 