### PR TITLE
Database plugin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     kaiser (0.4.5)
+      activesupport
       optimist
 
 GEM
@@ -108,4 +109,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ A Kaiserfile is made up of statements, which are different commands followed by 
 
 - `plugin` - Takes 1 parameter: the name of the plugin you wish to use in this Kaiserfile.
 
-```
+```ruby
 # Example
 plugin :git_submodule
 ```
@@ -112,42 +112,42 @@ See further below to find available plugins and their usage
 
 - `dockerfile` - This command is always required. Takes 1 parameter: the name of the Dockerfile you want to use with this Kaiserfile. You only need to use this command once. Using it multiple times will simply cause the last command to be used. It takes relative paths and the paths are relative to where you run Kaiser.
 
-```
+```ruby
 # Example
 dockerfile 'Dockerfile'
 ```
 
 - `attach_mount` - Takes 2 parameters: The first parameter is the relative path of a folder or a file outside the container and the second parameter is its absolute path inside the container. This is only used when `kaiser attach` or `kaiser up -a` is used. This will mount the file or folder inside the container and sync their contents. If the file you specified does not exist, Kaiser will create a folder where you specify it and then mount that folder inside the container. You can specify as many of these as you want.
 
-```
+```ruby
 # Example to mount the `app` directory into the container's `/srv/files/app`
 attach_mount 'app', '/srv/files/app'
 ```
 
 - `expose` - Takes 1 parameter: The port of the server running inside the container. This port is not exposed on the host, so it will not occupy a port on the computer you run kaiser on. Instead, Kaiser will select a random port on the host computer to forward traffic to and from. You can only use this statement once. If you have multiple of these statements the last one will be used.
 
-```
+```ruby
 # Example to expose the port 3636
 expose 3636
 ```
 
 - `app_params` - Takes 1 parameter: A string of parameters to the `docker run` command to add custom environment variables with. Please refer to the docker documentation to see what kinds of parameters you can pass to the `docker run` command. By default this is just an empty string. You can only pass one of these. Any newline characters in the string will be converted into spaces.
 
-```
+```ruby
 # Example
 app_params '-e INTERACTIVE=no'
 ```
 
 - `type` - Takes 1 parameter: Right now the only parameter it can take is `:http`. If this parameter is specified, kaiser will poll the application until it receives a 200 status code before it closes when you use `kaiser up` If it doesn't it will close with a status code of 1.
 
-```
+```ruby
 # Example
 type :http
 ```
 
 - `db_reset_command` - Takes 1 parameter: A command to reset the database. This command is optional. By default this parameter is `echo "no db to reset"`. You can only specify one of these. If you have multiple of these commands only the last one will be used.
 
-```
+```ruby
 # Example if running this command drops the db and recreates it.
 db_reset_command 'rake db:reset'
 ```
@@ -156,7 +156,7 @@ db_reset_command 'rake db:reset'
 
 (You do not have to use this strictly, see the Database Plugin below to see an easier way to include MySQL and Postgres in your environment)
 
-```
+```ruby
 # Default settings
 {
   image: 'alpine',
@@ -342,7 +342,7 @@ This plugin ensures that any submodules your repo has are checked out. If they a
 
 Usage:
 
-```
+```ruby
 plugin :git_submodule
 ```
 
@@ -354,7 +354,7 @@ This plugin allows you to specify well known DBs (MySQL and PostgresSQL) with de
 
 Usage:
 
-```
+```ruby
 # Simplest usage
 plugin :database
 
@@ -363,7 +363,7 @@ def_db :mysql
 
 If for example you wish to use a different root password, simply go
 
-```
+```ruby
 plugin :database
 
 def_db mysql: { root_password: 'extremesecret' }
@@ -371,7 +371,7 @@ def_db mysql: { root_password: 'extremesecret' }
 
 Sometimes you want to use a specific version for testing. You can set up the version by going
 
-```
+```ruby
 plugin :database
 
 def_db postgres: { version: '9.4' }
@@ -379,7 +379,7 @@ def_db postgres: { version: '9.4' }
 
 You can also pass startup parameters to your database server:
 
-```
+```ruby
 plugin :database
 
 def_db mysql: { parameters: '--verbose' }

--- a/README.md
+++ b/README.md
@@ -102,15 +102,62 @@ And enjoy previewing your app!
 A Kaiserfile is made up of statements, which are different commands followed by some parameters. Each command is just a ruby method so you can call it that way. Only the `dockerfile` command is required. All the other commands are either not required or have defaults.
 
 - `plugin` - Takes 1 parameter: the name of the plugin you wish to use in this Kaiserfile.
-- `dockerfile` - This command is always required. Takes 1 parameter: the name of the Dockerfile you want to use with this Kaiserfile. You only need to use this command once. Using it multiple times will simply cause the last command to be used.
-- `attach_mount` - Takes 2 parameters: The first parameter is the relative path of a folder or a file outside the container and the second parameter is its absolute path inside the container. This is only used when `kaiser attach` or `kaiser up -a` is used. This will mount the file or folder inside the container and sync their contents. If the file you specified does not exist, Kaiser will create a folder where you specify it and then mount that folder inside the container.
-- `expose` - Takes 1 parameter: The port of the server running inside the container. This port is not exposed on the host, so it will not occupy a port on the computer you run kaiser on. Instead, Kaiser will select a random port on the host computer to forward traffic to and from.
-- `app_params` - Takes 1 parameter: A string of parameters to the `docker run` command to add custom environment variables with. Please refer to the docker documentation to see what kinds of parameters you can pass to the `docker run` command. By default this is just an empty string.
-- `type` - Takes 1 parameter: Right now the only parameter it can take is `:http`. If this parameter is specified, kaiser will poll the application until it receives a 200 status code before it closes when you use `kaiser up` If it doesn't it will close with a status code of 1.
-- `db_reset_command` - Takes 1 parameter: A command to reset the database. This command is optional. By default this parameter is `echo "no db to reset"`
-- `db` - Takes 1 parameter in the form of a hash. The default value of the hash is as follows:
 
 ```
+# Example
+plugin :git_submodule
+```
+
+See further below to find available plugins and their usage
+
+- `dockerfile` - This command is always required. Takes 1 parameter: the name of the Dockerfile you want to use with this Kaiserfile. You only need to use this command once. Using it multiple times will simply cause the last command to be used. It takes relative paths and the paths are relative to where you run Kaiser.
+
+```
+# Example
+dockerfile 'Dockerfile'
+```
+
+- `attach_mount` - Takes 2 parameters: The first parameter is the relative path of a folder or a file outside the container and the second parameter is its absolute path inside the container. This is only used when `kaiser attach` or `kaiser up -a` is used. This will mount the file or folder inside the container and sync their contents. If the file you specified does not exist, Kaiser will create a folder where you specify it and then mount that folder inside the container. You can specify as many of these as you want.
+
+```
+# Example to mount the `app` directory into the container's `/srv/files/app`
+attach_mount 'app', '/srv/files/app'
+```
+
+- `expose` - Takes 1 parameter: The port of the server running inside the container. This port is not exposed on the host, so it will not occupy a port on the computer you run kaiser on. Instead, Kaiser will select a random port on the host computer to forward traffic to and from. You can only use this statement once. If you have multiple of these statements the last one will be used.
+
+```
+# Example to expose the port 3636
+expose 3636
+```
+
+- `app_params` - Takes 1 parameter: A string of parameters to the `docker run` command to add custom environment variables with. Please refer to the docker documentation to see what kinds of parameters you can pass to the `docker run` command. By default this is just an empty string. You can only pass one of these. Any newline characters in the string will be converted into spaces.
+
+```
+# Example
+app_params '-e INTERACTIVE=no'
+```
+
+- `type` - Takes 1 parameter: Right now the only parameter it can take is `:http`. If this parameter is specified, kaiser will poll the application until it receives a 200 status code before it closes when you use `kaiser up` If it doesn't it will close with a status code of 1.
+
+```
+# Example
+type :http
+```
+
+- `db_reset_command` - Takes 1 parameter: A command to reset the database. This command is optional. By default this parameter is `echo "no db to reset"`. You can only specify one of these. If you have multiple of these commands only the last one will be used.
+
+```
+# Example if running this command drops the db and recreates it.
+db_reset_command 'rake db:reset'
+```
+
+- `db` - Takes 1 parameter in the form of a hash. The default value of the hash is as follows:
+
+(You do not have to use this strictly, see the Database Plugin below to see an easier way to include MySQL and Postgres in your environment)
+
+```
+# Default settings
 {
   image: 'alpine',
   port: 1234,
@@ -284,6 +331,59 @@ kaiser up
 ```
 
 Again for changes to take effect.
+
+## Plugins
+
+Kaiser has a plugin system that adds commands to the Kaiserfile to help improve your workflow. Below are a list of built-in plugins that come with Kaiser.
+
+### Git Submodules Plugin
+
+This plugin ensures that any submodules your repo has are checked out. If they are not, it will cause Kaiser to exit with a status code of 1.
+
+Usage:
+
+```
+plugin :git_submodule
+```
+
+That's all you need!
+
+### Database Plugin
+
+This plugin allows you to specify well known DBs (MySQL and PostgresSQL) with default values that work generally. You can customize your database however you want it for your own project.
+
+Usage:
+
+```
+# Simplest usage
+plugin :database
+
+def_db :mysql
+```
+
+If for example you wish to use a different root password, simply go
+
+```
+plugin :database
+
+def_db mysql: { root_password: 'extremesecret' }
+```
+
+Sometimes you want to use a specific version for testing. You can set up the version by going
+
+```
+plugin :database
+
+def_db postgres: { version: '9.4' }
+```
+
+You can also pass startup parameters to your database server:
+
+```
+plugin :database
+
+def_db mysql: { parameters: '--verbose' }
+```
 
 ## Development
 

--- a/kaiser.gemspec
+++ b/kaiser.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'activesupport'
   spec.add_dependency 'optimist'
 
   spec.add_development_dependency 'aruba'

--- a/lib/kaiser/databases/mysql.rb
+++ b/lib/kaiser/databases/mysql.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Kaiser
+  module Databases
+    class Mysql
+      def initialize(options)
+        @options = options
+      end
+
+      def options_hash
+        testpass = @options[:root_password] || 'testpassword'
+        parameters = @options[:parameters] || ''
+        port = @options[:port] || 3306
+
+        {
+          port: port,
+          data_dir: '/var/lib/mysql',
+          params: "-e MYSQL_ROOT_PASSWORD=#{testpass}",
+          commands: parameters,
+          waitscript_params: "
+            -e MYSQL_ADDR=<%= db_container_name %>
+            -e MYSQL_PORT=#{port}
+            -e MYSQL_ROOT_PASSWORD=#{testpass}",
+          waitscript: <<~SCRIPT
+            #!/bin/bash
+
+            echo "Waiting for mysql to start."
+            until mysql -h"$MYSQL_ADDR" -P"$MYSQL_PORT" -uroot -p"$MYSQL_ROOT_PASSWORD" -e "SELECT 1"
+            do
+              printf "."
+              sleep 1
+            done
+
+            echo -e "\nmysql started."
+          SCRIPT
+        }
+      end
+
+      def image_name
+        version = @options[:version] || '5.6'
+        "mysql:#{version}"
+      end
+    end
+  end
+end

--- a/lib/kaiser/databases/postgres.rb
+++ b/lib/kaiser/databases/postgres.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Kaiser
+  module Databases
+    class Postgres
+      def initialize(options)
+        @options = options
+      end
+
+      def options_hash
+        testpass = @options[:root_password] || 'testpassword'
+        parameters = @options[:parameters] || ''
+        port = @options[:port] || 3306
+
+        {
+          port: port,
+          data_dir: '/var/lib/postgresql/data',
+          params: "-e POSTGRES_PASSWORD=#{testpass}",
+          commands: parameters,
+          waitscript_params: "
+            -e PG_HOST=<%= db_container_name %>
+            -e PG_USER=postgres
+            -e PGPASSWORD=#{testpass}
+            -e PG_DATABASE=postgres",
+          waitscript: <<~SCRIPT
+            #!/bin/sh
+
+            RETRIES=5
+
+            until psql -h $PG_HOST -U $PG_USER -d $PG_DATABASE -c "select 1" > /dev/null 2>&1 || [ $RETRIES -eq 0 ]; do
+             echo "Waiting for postgres server, $((RETRIES--)) remaining attempts..."
+             sleep 1
+            done
+          SCRIPT
+        }
+      end
+
+      def image_name
+        version = @options[:version] || 'alpine'
+        "postgres:#{version}"
+      end
+    end
+  end
+end

--- a/lib/kaiser/plugins/database.rb
+++ b/lib/kaiser/plugins/database.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'active_support/inflector'
+
+module Kaiser
+  module Plugins
+    class Database < Plugin
+      def on_init
+        @kaiserfile.define_singleton_method :def_db do |*args|
+          args[0] = { args.first => {} } unless args.first.is_a? Hash
+
+          option = args.first
+
+          driver_name = option.keys.first.to_s
+
+          begin
+            require "kaiser/databases/#{driver_name}"
+          rescue LoadError
+            raise "Unknown database '#{driver_name}'"
+          end
+
+          driver_class = Kaiser::Databases.const_get(driver_name.camelize)
+          db_driver = driver_class.new(option.values.first)
+
+          db(db_driver.image_name, **db_driver.options_hash)
+        end
+      end
+    end
+  end
+end

--- a/lib/kaiser/version.rb
+++ b/lib/kaiser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kaiser
-  VERSION = '0.4.5'
+  VERSION = '0.4.6'
 end

--- a/spec/plugins/database_spec.rb
+++ b/spec/plugins/database_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Kaiser::Plugins::Database' do
+  before do
+    # stub out call that isnt supposed to be there anyway
+    require 'optimist'
+    allow(Optimist).to receive(:die)
+  end
+
+  let(:dockerfile_name) { 'Dockerfile.kaiser' }
+  let(:kaiserfile_name) { 'Kaiserfile' }
+  let(:dockerfile) { 'FROM ruby:alpine' }
+  let(:kaiserfile) { <<~KAISERFILE }
+    plugin :database
+    dockerfile "Dockerfile.kaiser"
+  KAISERFILE
+
+  before do
+    allow(File).to receive(:exist?) { true }
+    allow(File).to receive(:read).with(kaiserfile_name) { kaiserfile }
+    allow(File).to receive(:read).with(dockerfile_name) { dockerfile }
+  end
+
+  it 'throws an exception if nonexistent driver' do
+    kaiserfile = Kaiser::Kaiserfile.new('Kaiserfile')
+
+    expect { kaiserfile.def_db :nobase }.to raise_error "Unknown database 'nobase'"
+  end
+
+  context 'given a driver' do
+    let(:db_class) { Class.new }
+    let(:db_driver) { instance_double('Kaiser::Databases::Somebase') }
+
+    before do
+      stub_const('Kaiser::Databases::Somebase', db_class)
+    end
+
+    it 'accepts a symbol and loads the appropriate driver' do
+      kaiserfile = Kaiser::Kaiserfile.new('Kaiserfile')
+      allow(kaiserfile).to receive(:require).with('kaiser/databases/somebase') { true }
+
+      expect(db_class).to receive(:new) { db_driver }
+      expect(db_driver).to receive(:options_hash) { { port: 1234 } }
+      expect(db_driver).to receive(:image_name) { '' }
+      expect(kaiserfile).to receive(:db).with('', port: 1234)
+
+      kaiserfile.def_db :somebase
+    end
+
+    it 'accepts a hash and loads the appropriate driver' do
+      kaiserfile = Kaiser::Kaiserfile.new('Kaiserfile')
+      allow(kaiserfile).to receive(:require).with('kaiser/databases/somebase') { true }
+
+      expect(db_class).to receive(:new) { db_driver }.with(hello: :meow)
+      expect(db_driver).to receive(:options_hash) { { port: 1234 } }
+      expect(db_driver).to receive(:image_name) { '' }
+      expect(kaiserfile).to receive(:db).with('', port: 1234)
+
+      kaiserfile.def_db somebase: { hello: :meow }
+    end
+  end
+end


### PR DESCRIPTION
# Context

This PR adds the ability to include MySQL and Postgres easily into your Kaiserfile, making it easier to start on a project. The plugin does most of the heavy lifting demanded by the `db` command, while still letting the user write his own `db` command if he is using another database.

To use it you simply add

```ruby
plugin :database

# and then make it so Kaiser starts a mysql database for your project
def_db :mysql
```

## How to test
1. Check out https://github.com/degica/kaisertest
2. `cd db_test`
3. Change the path in the Gemfile to where you checked out Kaiser on your PC
4. `bundle install`
5. `kaiser init db_test`
6. `kaiser up -v`
7. Check that the container `db_test-db` is upped and that you can `kaiser db_save` and `kaiser db_load`