### PR TITLE
[WIP] Add an after-start-script command to kaiserfile

### DIFF
--- a/lib/kaiser/cli.rb
+++ b/lib/kaiser/cli.rb
@@ -330,6 +330,7 @@ module Kaiser
       CommandRunner.run! Config.out, "docker cp .after_start_script #{app_container_name}:/tmp"
       CommandRunner.run! Config.out, "docker exec -t --user=root #{app_container_name} chmod +x /tmp/.after_start_script"
       CommandRunner.run! Config.out, "docker exec -t #{app_container_name} /tmp/.after_start_script"
+      CommandRunner.run! Config.out, "rm .after_start_script"
 
       Config.info_out.puts 'Started successfully!'
     end

--- a/lib/kaiser/kaiserfile.rb
+++ b/lib/kaiser/kaiserfile.rb
@@ -10,7 +10,8 @@ module Kaiser
                   :database_reset_command,
                   :attach_mounts,
                   :server_type,
-                  :services
+                  :services,
+                  :after_start_script
 
     def initialize(filename)
       Optimist.die 'No Kaiserfile in current directory' unless File.exist? filename
@@ -30,6 +31,7 @@ module Kaiser
       @database_reset_command = 'echo "no db to reset"'
       @port = 1234
       @services = {}
+      @after_start_script = ''
 
       instance_eval File.read(filename), filename
     end
@@ -92,6 +94,10 @@ module Kaiser
       raise 'Valid server types are: [:http]' if value != :http
 
       @server_type = value
+    end
+
+    def after_start(script)
+      @after_start_script = script
     end
 
     def service(name, image: name)


### PR DESCRIPTION
This thing adds the ability to run a script after the server starts. Useful if you wish to perform some development setup