### PR TITLE
Don't use hidden config files.

### DIFF
--- a/lib/kaiser/cli.rb
+++ b/lib/kaiser/cli.rb
@@ -144,7 +144,7 @@ module Kaiser
         #{app_params}
         kaiser:#{envname}-#{current_branch} #{db_reset_command}"
 
-      save_db('.default')
+      save_db('default')
     end
 
     def save_db(name)
@@ -226,7 +226,7 @@ module Kaiser
     end
 
     def default_db_image
-      db_image_path('.default')
+      db_image_path('default')
     end
 
     def attach_app
@@ -272,11 +272,11 @@ module Kaiser
     end
 
     def tmp_waitscript_name
-      "#{Config.config_dir}/.#{envname}-dbwaitscript"
+      "#{Config.config_dir}/#{envname}-dbwaitscript"
     end
 
     def tmp_dockerfile_name
-      "#{Config.config_dir}/.#{envname}-dockerfile"
+      "#{Config.config_dir}/#{envname}-dockerfile"
     end
 
     def tmp_db_waiter

--- a/lib/kaiser/cmds/db_load.rb
+++ b/lib/kaiser/cmds/db_load.rb
@@ -11,7 +11,7 @@ module Kaiser
 
           Alternatively you can also load it from your current directory.
 
-          If no database name was provided, the default database stored at \`~/.kaiser/<ENV_NAME>/<current_github_branch_name>/.default.tar.bz\` will be used.
+          If no database name was provided, the default database stored at \`~/.kaiser/<ENV_NAME>/<current_github_branch_name>/default.tar.bz\` will be used.
 
           USAGE: kaiser db_load
                  kaiser db_load DB_BACKUP_FILENAME
@@ -21,7 +21,7 @@ module Kaiser
 
       def execute(_opts)
         ensure_setup
-        name = ARGV.shift || '.default'
+        name = ARGV.shift || 'default'
         load_db(name)
       end
     end

--- a/lib/kaiser/cmds/db_reset.rb
+++ b/lib/kaiser/cmds/db_reset.rb
@@ -5,7 +5,7 @@ module Kaiser
     class DbReset < Cli
       def usage
         <<~EOS
-          Shuts down the database docker container, *replaces* the database with the default database image stored at \`~/.kaiser/<ENV_NAME>/<current_github_branch_name>/.default.tar.bz\` and brings the container up again.
+          Shuts down the database docker container, *replaces* the database with the default database image stored at \`~/.kaiser/<ENV_NAME>/<current_github_branch_name>/default.tar.bz\` and brings the container up again.
 
           This is the same as running \`kaiser db_load\` with no arguments.
 
@@ -15,7 +15,7 @@ module Kaiser
 
       def execute(_opts)
         ensure_setup
-        load_db('.default')
+        load_db('default')
       end
     end
   end

--- a/lib/kaiser/cmds/db_reset_hard.rb
+++ b/lib/kaiser/cmds/db_reset_hard.rb
@@ -5,7 +5,7 @@ module Kaiser
     class DbResetHard < Cli
       def usage
         <<~EOS
-          Shuts down the database docker container, deletes the docker volume on which the db was stored, deletes the default database image stored at \`~/.kaiser/<ENV_NAME>/<current_github_branch_name>/.default.tar.bz\`, rebuilds the docker volume and the default database image from scratch and then brings the container up again.
+          Shuts down the database docker container, deletes the docker volume on which the db was stored, deletes the default database image stored at \`~/.kaiser/<ENV_NAME>/<current_github_branch_name>/default.tar.bz\`, rebuilds the docker volume and the default database image from scratch and then brings the container up again.
 
           USAGE: kaiser db_reset_hard
         EOS
@@ -13,7 +13,7 @@ module Kaiser
 
       def execute(_opts)
         ensure_setup
-        FileUtils.rm db_image_path('.default') if File.exist?(db_image_path('.default'))
+        FileUtils.rm db_image_path('default') if File.exist?(db_image_path('default'))
         setup_db
       end
     end

--- a/lib/kaiser/cmds/db_save.rb
+++ b/lib/kaiser/cmds/db_save.rb
@@ -18,7 +18,7 @@ module Kaiser
 
       def execute(_opts)
         ensure_setup
-        name = ARGV.shift || '.default'
+        name = ARGV.shift || 'default'
         save_db(name)
       end
     end

--- a/lib/kaiser/cmds/up.rb
+++ b/lib/kaiser/cmds/up.rb
@@ -9,7 +9,7 @@ module Kaiser
         <<~EOS
           Boots up the application in docker as defined in the \`Kaiserfile\` in its source code. Usually this will create two docker containers \`<ENV_NAME>-db\` and \`<ENV_NAME>-app\` running your database and application respectively.
 
-          A backup of the default database is created and saved to \`~/.kaiser/<ENV_NAME>/<current_github_branch_name>/.default.tar.bz\`. This can be restored at any time using the \`db_reset\` command.
+          A backup of the default database is created and saved to \`~/.kaiser/<ENV_NAME>/<current_github_branch_name>/default.tar.bz\`. This can be restored at any time using the \`db_reset\` command.
 
           USAGE: kaiser up
         EOS

--- a/lib/kaiser/config.rb
+++ b/lib/kaiser/config.rb
@@ -59,7 +59,7 @@ module Kaiser
       # files in case you have just upgraded from an older version.
       def migrate_dotted_config_files
         if File.exists?("#{@config_dir}/.config.yml")
-          # This shell one-liner recursively finds all files start start with a dot and remove said dot
+          # This shell one-liner recursively finds all files that start with a dot and removes said dot
           `find #{@config_dir} -type f -name '.*' -execdir sh -c 'mv -i "$0" "./${0#./.}"' {} \\;`
         end
       end

--- a/lib/kaiser/config.rb
+++ b/lib/kaiser/config.rb
@@ -53,7 +53,7 @@ module Kaiser
 
       def migrate_dotted_config_files
         if File.exists?("#{@config_dir}/.config.yml")
-          `find #{@config_dir} -type f -name '.*' -execdir sh -c 'mv -i "$0" "./${0#./.}"' {} \;`
+          `find #{@config_dir} -type f -name '.*' -execdir sh -c 'mv -i "$0" "./${0#./.}"' {} \\;`
         end
       end
 

--- a/lib/kaiser/config.rb
+++ b/lib/kaiser/config.rb
@@ -56,10 +56,10 @@ module Kaiser
       # Kaiser 0.5.2 started using non-dotted files instead. This method renames the old
       # files in case you have just upgraded from an older version.
       def migrate_dotted_config_files
-        if File.exists?("#{@config_dir}/.config.yml")
-          # This shell one-liner recursively finds all files that start with a dot and removes said dot
-          `find #{@config_dir} -type f -name '.*' -execdir sh -c 'mv -i "$0" "./${0#./.}"' {} \\;`
-        end
+        return unless File.exist?("#{@config_dir}/.config.yml")
+
+        # This shell one-liner recursively finds all files that start with a dot and removes said dot
+        `find #{@config_dir} -type f -name '.*' -execdir sh -c 'mv -i "$0" "./${0#./.}"' {} \\;`
       end
 
       def load_config

--- a/lib/kaiser/config.rb
+++ b/lib/kaiser/config.rb
@@ -18,8 +18,10 @@ module Kaiser
         @work_dir = work_dir
         @config_dir = "#{ENV['HOME']}/.kaiser"
 
+        migrate_dotted_config_files
+
         FileUtils.mkdir_p @config_dir
-        @config_file = "#{@config_dir}/.config.yml"
+        @config_file = "#{@config_dir}/config.yml"
         @kaiserfile = Kaiserfile.new("#{@work_dir}/Kaiserfile")
 
         @config = {
@@ -47,6 +49,12 @@ module Kaiser
 
       def always_verbose?
         @config[:always_verbose]
+      end
+
+      def migrate_dotted_config_files
+        if File.exists?("#{@config_dir}/.config.yml")
+          `find #{@config_dir} -type f -name '.*' -execdir sh -c 'mv -i "$0" "./${0#./.}"' {} \;`
+        end
       end
 
       def load_config

--- a/lib/kaiser/config.rb
+++ b/lib/kaiser/config.rb
@@ -51,8 +51,15 @@ module Kaiser
         @config[:always_verbose]
       end
 
+      # Up until version 0.5.1, kaiser used dotfiles for all of it configuration.
+      # It makes sense of hide the configuration directory itself but hiding the files
+      # inside of it just causes confusion.
+      #
+      # Kaiser 0.5.2 started using non-dotted files instead. This method renames the old
+      # files in case you have just upgraded from an older version.
       def migrate_dotted_config_files
         if File.exists?("#{@config_dir}/.config.yml")
+          # This shell one-liner recursively finds all files start start with a dot and remove said dot
           `find #{@config_dir} -type f -name '.*' -execdir sh -c 'mv -i "$0" "./${0#./.}"' {} \\;`
         end
       end

--- a/lib/kaiser/version.rb
+++ b/lib/kaiser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kaiser
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end


### PR DESCRIPTION
CI is failing due to unrelated linter errors that are fixed in https://github.com/degica/kaiser/pull/67

The way to usually store config files on *nix systems is to have either a single hidden file in the home directory or a hidden directory with non-hidden files inside.

Kaiser used a hidden directory with hidden files inside which was confusing. I updated it to use the more common hidden directory with non-hidden files pattern.

I've set it up so that kaiser will checked for the hidden files on boot and un-hide them if they exist.