### PR TITLE
Disable db work when no db specified

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -53,7 +53,8 @@ Metrics/BlockLength:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 448
+  Exclude:
+    - 'lib/kaiser/cli.rb'
 
 # Offense count: 1
 # Configuration parameters: IgnoredMethods.

--- a/lib/kaiser/kaiserfile.rb
+++ b/lib/kaiser/kaiserfile.rb
@@ -16,7 +16,7 @@ module Kaiser
       Optimist.die 'No Kaiserfile in current directory' unless File.exist? filename
 
       @database = {
-        image: 'alpine',
+        image: 'none',
         port: 1234,
         data_dir: '/tmp/data',
         params: '',

--- a/lib/kaiser/version.rb
+++ b/lib/kaiser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kaiser
-  VERSION = '0.5.2'
+  VERSION = '0.5.3'
 end

--- a/spec/kaiserfile_spec.rb
+++ b/spec/kaiserfile_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Kaiser::Kaiserfile do
 
       it 'sets up the database variable to defaults' do
         kaiserfile = Kaiser::Kaiserfile.new('Kaiserfile')
-        expect(kaiserfile.database[:image]).to eq 'alpine'
+        expect(kaiserfile.database[:image]).to eq 'none'
         expect(kaiserfile.database[:data_dir]).to eq '/tmp/data'
         expect(kaiserfile.database[:port]).to eq 1234
         expect(kaiserfile.database[:params]).to eq ''


### PR DESCRIPTION
This PR disables any db work when a `db` parameter is omitted from the Kaiserfile.