### PR TITLE
Fix migration incompatibility

### DIFF
--- a/lib/kaiser/config.rb
+++ b/lib/kaiser/config.rb
@@ -58,8 +58,11 @@ module Kaiser
       def migrate_dotted_config_files
         return unless File.exist?("#{@config_dir}/.config.yml")
 
-        # This shell one-liner recursively finds all files that start with a dot and removes said dot
-        `find #{@config_dir} -type f -name '.*' -execdir sh -c 'mv -i "$0" "./${0#./.}"' {} \\;`
+        Dir["#{@config_dir}/**/.*"].each do |x|
+          dest = x.sub(%r{/\.([a-z\.]+)$}, '/\1')
+          #puts "#{x} -> #{dest}"
+          FileUtils.mv x, dest
+        end
       end
 
       def load_config

--- a/lib/kaiser/config.rb
+++ b/lib/kaiser/config.rb
@@ -59,8 +59,7 @@ module Kaiser
         return unless File.exist?("#{@config_dir}/.config.yml")
 
         Dir["#{@config_dir}/**/.*"].each do |x|
-          dest = x.sub(%r{/\.([a-z\.]+)$}, '/\1')
-          #puts "#{x} -> #{dest}"
+          dest = x.sub(%r{/\.([a-z.]+)$}, '/\1')
           FileUtils.mv x, dest
         end
       end


### PR DESCRIPTION
This fixes the migration for config dotfiles. It is done by a oneliner that unfortunately only works in bash. We write a procedural version here that is compatible with any system that uses ruby.

You can test this manually by
1. rename your `~/.kaiser/config.yml` to `~/.kaiser/.config.yml`
2. run kaiser up
3. and check that `ls -a ~/.kaiser` will show you no dotfiles.