### PR TITLE
Fix platforms when using db plugin

### DIFF
--- a/lib/kaiser/databases/postgres.rb
+++ b/lib/kaiser/databases/postgres.rb
@@ -11,12 +11,14 @@ module Kaiser
         testpass = @options[:root_password] || 'testpassword'
         parameters = @options[:parameters] || ''
         port = @options[:port] || 3306
+        platform = @options[:platform] || 'linux/amd64'
 
         {
           port: port,
           data_dir: '/var/lib/postgresql/data',
           params: "-e POSTGRES_PASSWORD=#{testpass}",
           commands: parameters,
+          platform: platform,
           waitscript_params: "
             -e PG_HOST=<%= db_container_name %>
             -e PG_USER=postgres

--- a/lib/kaiser/version.rb
+++ b/lib/kaiser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kaiser
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end


### PR DESCRIPTION
This adds the ability to set the platform when using the DB plugin, needed for certain databases.