### PR TITLE
bump version

### DIFF
--- a/lib/kaiser/version.rb
+++ b/lib/kaiser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kaiser
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
 end


### PR DESCRIPTION
bump version to 0.6.2. this PR allows us to push a new version to rubygems.