### PR TITLE
start up redis 7

### DIFF
--- a/lib/kaiser/cli.rb
+++ b/lib/kaiser/cli.rb
@@ -534,7 +534,7 @@ module Kaiser
         "docker run -d
           --name #{Config.config[:shared_names][:redis]}
           --network #{Config.config[:networkname]}
-          redis:alpine"
+          redis:alpine:7"
       )
       run_if_dead(
         Config.config[:shared_names][:chrome],

--- a/lib/kaiser/cli.rb
+++ b/lib/kaiser/cli.rb
@@ -534,7 +534,7 @@ module Kaiser
         "docker run -d
           --name #{Config.config[:shared_names][:redis]}
           --network #{Config.config[:networkname]}
-          redis:alpine:7"
+          redis:7-alpine"
       )
       run_if_dead(
         Config.config[:shared_names][:chrome],

--- a/lib/kaiser/version.rb
+++ b/lib/kaiser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kaiser
-  VERSION = '0.6.5'
+  VERSION = '0.6.7'
 end


### PR DESCRIPTION
This makes Kaiser start up a redis 7 instance, letting us start standardizing on this version of Redis