### PR TITLE
Make Kaiser work on ARM macs

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -3,7 +3,7 @@ name: default
 jobs:
   rspec:
     container:
-      image: ruby:2.7
+      image: ruby:3.0
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -23,7 +23,7 @@ jobs:
       run: bundle exec rspec
   rubocop:
     container:
-      image: ruby:2.7
+      image: ruby:3.0
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,7 @@
 inherit_from: .rubocop_todo.yml
+
+# don't look at blocklength for specs
+# its basically what they do anyway
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -43,7 +43,7 @@ Lint/ConstantDefinitionInBlock:
 # Offense count: 11
 # Configuration parameters: AllowedMethods, AllowedPatterns, IgnoredMethods, CountRepeatedAttributes.
 Metrics/AbcSize:
-  Max: 57
+  Max: 58
 
 # Offense count: 7
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, AllowedMethods, AllowedPatterns, IgnoredMethods.

--- a/lib/kaiser/cmds/shutdown.rb
+++ b/lib/kaiser/cmds/shutdown.rb
@@ -14,7 +14,7 @@ module Kaiser
       end
 
       def execute(_opts)
-        Config.config[:shared_names].each do |_, container_name|
+        Config.config[:shared_names].each_value do |container_name|
           killrm container_name
         end
 

--- a/lib/kaiser/cmds/up.rb
+++ b/lib/kaiser/cmds/up.rb
@@ -28,14 +28,24 @@ module Kaiser
         end
       end
 
+      def build_cmd
+        platform_args = ''
+        platform_args = "--platform=#{force_platform}" unless force_platform.empty?
+        build_args = docker_build_args.map { |k, v| "--build-arg #{k}=#{v}" }
+        [
+          'docker build',
+          "-t kaiser:#{envname}-#{current_branch}",
+          "-f #{tmp_dockerfile_name} #{Config.work_dir}",
+          platform_args,
+          build_args.join(' ').to_s
+        ]
+      end
+
       def setup_app
         Config.info_out.puts 'Setting up application'
         File.write(tmp_dockerfile_name, docker_file_contents)
-        build_args = docker_build_args.map { |k, v| "--build-arg #{k}=#{v}" }
-        CommandRunner.run! Config.out, "docker build
-          -t kaiser:#{envname}-#{current_branch}
-          -f #{tmp_dockerfile_name} #{Config.work_dir}
-          #{build_args.join(' ')}"
+
+        CommandRunner.run! Config.out, build_cmd.join("\n\t")
         FileUtils.rm(tmp_dockerfile_name)
       end
     end

--- a/lib/kaiser/kaiserfile.rb
+++ b/lib/kaiser/kaiserfile.rb
@@ -76,6 +76,10 @@ module Kaiser
       }
     end
 
+    def force_platform(platform_name)
+      @platform = platform_name
+    end
+
     def expose(port)
       @port = port
     end

--- a/lib/kaiser/version.rb
+++ b/lib/kaiser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kaiser
-  VERSION = '0.6.7'
+  VERSION = '0.7.0'
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -46,4 +46,24 @@ RSpec.describe Kaiser::Kaiserfile do
       expect(cli.send(:db_image)).to eq('postgres:alpine')
     end
   end
+
+  describe '#selenium_node_image' do
+    it 'for x86 machines returns normal selenium' do
+      cli = Kaiser::Cli.new
+      stub_const('RUBY_PLATFORM', 'x86_64-linux')
+      expect(cli.send(:selenium_node_image)).to eq('selenium/standalone-chrome-debug')
+    end
+
+    it 'for arm machines on mac' do
+      cli = Kaiser::Cli.new
+      stub_const('RUBY_PLATFORM', 'arm64-darwin23')
+      expect(cli.send(:selenium_node_image)).to eq('seleniarm/standalone-chromium')
+    end
+
+    it 'for arm machines on linux' do
+      cli = Kaiser::Cli.new
+      stub_const('RUBY_PLATFORM', 'aarch64-linux')
+      expect(cli.send(:selenium_node_image)).to eq('seleniarm/standalone-chromium')
+    end
+  end
 end

--- a/spec/cmds/up_spec.rb
+++ b/spec/cmds/up_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe Kaiser::Cmds::Up do
+  describe 'cmd' do
+    it 'generates correctly' do
+      kaiserfile = double(Kaiser::Kaiserfile)
+      kaiserconfig = double(Kaiser::Config)
+
+      allow(Kaiser::Config).to receive(:kaiserfile).and_return(kaiserfile)
+      allow(Kaiser::Config).to receive(:config).and_return(kaiserconfig)
+
+      allow(Kaiser::Config).to receive(:work_dir).and_return('somedir')
+
+      envs = double('Hash')
+      allow(envs).to receive(:[]).with('somedir').and_return('meow')
+
+      allow(Kaiser::Config.kaiserfile).to receive(:docker_build_args).and_return({})
+      allow(Kaiser::Config.config).to receive(:[]).with(:envnames).and_return(envs)
+
+      obj = described_class.new
+      allow(obj).to receive(:current_branch).and_return('master')
+
+      allow(kaiserfile).to receive(:platform).and_return('')
+
+      expect(obj.build_cmd[0]).to eq 'docker build'
+      expect(obj.build_cmd[1]).to eq '-t kaiser:meow-master'
+      expect(obj.build_cmd[2]).to eq '-f /meow-dockerfile somedir'
+      expect(obj.build_cmd[3].to_s).to eq ''
+    end
+
+    it 'generates the appropriate build platform' do
+      kaiserfile = double(Kaiser::Kaiserfile)
+      kaiserconfig = double(Kaiser::Config)
+
+      allow(Kaiser::Config).to receive(:kaiserfile).and_return(kaiserfile)
+      allow(Kaiser::Config).to receive(:config).and_return(kaiserconfig)
+
+      allow(Kaiser::Config).to receive(:work_dir).and_return('somedir')
+
+      envs = double('Hash')
+      allow(envs).to receive(:[]).with('somedir').and_return('meow')
+
+      allow(kaiserfile).to receive(:platform).and_return('linux/catcpu')
+
+      allow(Kaiser::Config.kaiserfile).to receive(:docker_build_args).and_return({})
+      allow(Kaiser::Config.config).to receive(:[]).with(:envnames).and_return(envs)
+
+      obj = described_class.new
+      allow(obj).to receive(:current_branch).and_return('master')
+
+      allow(kaiserfile).to receive(:platform).and_return('linux/catcpu')
+
+      expect(obj.build_cmd[0]).to eq 'docker build'
+      expect(obj.build_cmd[1]).to eq '-t kaiser:meow-master'
+      expect(obj.build_cmd[2]).to eq '-f /meow-dockerfile somedir'
+      expect(obj.build_cmd[3]).to eq '--platform=linux/catcpu'
+    end
+  end
+end

--- a/spec/kaiserfile_spec.rb
+++ b/spec/kaiserfile_spec.rb
@@ -171,6 +171,26 @@ RSpec.describe Kaiser::Kaiserfile do
     end
   end
 
+  context '#force_platform' do
+    context 'when force_platform is specified' do
+      let(:kaiserfile_contents) { "force_platform 'catcpu'" }
+
+      it 'sets platform' do
+        kaiserfile = Kaiser::Kaiserfile.new('Kaiserfile')
+        expect(kaiserfile.platform).to eq('catcpu')
+      end
+    end
+
+    context 'when force_platform is not specified' do
+      let(:kaiserfile_contents) { '' }
+
+      it 'platform is nil' do
+        kaiserfile = Kaiser::Kaiserfile.new('Kaiserfile')
+        expect(kaiserfile.platform).to be_nil
+      end
+    end
+  end
+
   context '#service' do
     context 'when service is specified' do
       let(:kaiserfile_contents) { "service 'santaclaus'" }

--- a/spec/plugins/database_spec.rb
+++ b/spec/plugins/database_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Kaiser::Plugins::Database' do
       kaiserfile = Kaiser::Kaiserfile.new('Kaiserfile')
       allow(kaiserfile).to receive(:require).with('kaiser/databases/somebase') { true }
 
-      expect(db_class).to receive(:new) { db_driver }.with(hello: :meow)
+      expect(db_class).to receive(:new) { db_driver }.with({ hello: :meow })
       expect(db_driver).to receive(:options_hash) { { port: 1234 } }
       expect(db_driver).to receive(:image_name) { '' }
       expect(kaiserfile).to receive(:db).with('', port: 1234)


### PR DESCRIPTION
Bunch of upgrades to bring kaiser into the new century. Kaiser had encountered some strange difficulties including

- not working chrome testing on arm (strange crashing every once in a while)
- not starting some applications mysteriously (because they cant start on ARM)
- mysterious failures with new system ruby

hence this PR:

Update to 3.0
Thanks to my nice ARM pc now I got everything working real nice
Make the chrome work for both ARM and AMD64 procs

How to test (or trust me completely):

1. check out this repo and this branch `git clone https://github.com/degica/kaiser && cd kaiser && git checkout add-build-platform`
2. `rake build`
3. go to somewhere like HATS and go `gem install ../kaiser/pkg/kaiser-0.7.0.gem`
4. `kaiser init hats` and `kaiser up -av`
5. go to `http://hats.lvh.me` in your browser

should work

Test testing
1. `kaiser up -av bash`
2. `rspec spec/features`
3. use your favorite VNC tool and go to localhost:5900 with the password `secret` and see the tests running


