### PR TITLE
Service feature

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,7 @@ inherit_from: .rubocop_todo.yml
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*.rb'
+
+Layout/LineLength:
+  Exclude:
+    - 'spec/**/*'

--- a/lib/kaiser/cli.rb
+++ b/lib/kaiser/cli.rb
@@ -110,11 +110,7 @@ module Kaiser
       services.each do |service|
         Config.info_out.puts "Starting service: #{service.name}"
         run_if_dead(
-          service.shared_name,
-          "docker run -d
-            --name #{service.shared_name}
-            --network #{Config.config[:networkname]}
-            #{service.image}"
+          service.shared_name, service.start_docker_command
         )
       end
     end
@@ -246,6 +242,10 @@ module Kaiser
     end
 
     def attach_app
+      start_services
+
+      puts "Attaching to app..."
+
       cmd = (ARGV || []).join(' ')
       killrm app_container_name
 
@@ -264,6 +264,8 @@ module Kaiser
         #{volumes}
         #{app_params}
         kaiser:#{envname}-#{current_branch} #{cmd}".tr("\n", ' ')
+
+      stop_services
 
       Config.out.puts 'Cleaning up...'
     end

--- a/lib/kaiser/cli.rb
+++ b/lib/kaiser/cli.rb
@@ -244,7 +244,7 @@ module Kaiser
     def attach_app
       start_services
 
-      puts "Attaching to app..."
+      puts 'Attaching to app...'
 
       cmd = (ARGV || []).join(' ')
       killrm app_container_name

--- a/lib/kaiser/kaiserfile.rb
+++ b/lib/kaiser/kaiserfile.rb
@@ -102,10 +102,20 @@ module Kaiser
       @server_type = value
     end
 
-    def service(name, image: name)
+    def service(name,
+      image: name,
+      command: nil,
+      binds: {},
+      env: {})
+
       raise "duplicate service #{name.inspect}" if @services.key?(name)
 
-      @services[name] = { image: image }
+      @services[name] = {
+        image: image,
+        command: command,
+        binds: binds,
+        env: env
+      }
     end
   end
 end

--- a/lib/kaiser/kaiserfile.rb
+++ b/lib/kaiser/kaiserfile.rb
@@ -103,10 +103,10 @@ module Kaiser
     end
 
     def service(name,
-      image: name,
-      command: nil,
-      binds: {},
-      env: {})
+                image: name,
+                command: nil,
+                binds: {},
+                env: {})
 
       raise "duplicate service #{name.inspect}" if @services.key?(name)
 

--- a/lib/kaiser/service.rb
+++ b/lib/kaiser/service.rb
@@ -32,18 +32,18 @@ module Kaiser
     end
 
     def start_docker_command
-      envstring = env.map do |k,v|
+      envstring = env.map do |k, v|
         "-e #{k}=#{v}"
       end.join(' ')
 
-      bindstring = binds.map do |k,v|
+      bindstring = binds.map do |k, v|
         "-v #{k}:#{v}"
       end.join(' ')
 
       commandstring = command
 
       cmd_array = [
-        "docker run -d",
+        'docker run -d',
         "--name #{shared_name}",
         "--network #{Config.config[:networkname]}",
         envstring,
@@ -52,9 +52,9 @@ module Kaiser
         commandstring
       ]
 
-      cmd_array.filter! {|x| !x.empty?}
+      cmd_array.filter! { |x| !x.empty? }
 
-      cmd_array.join(" ")
+      cmd_array.join(' ')
     end
   end
 end

--- a/lib/kaiser/service.rb
+++ b/lib/kaiser/service.rb
@@ -18,5 +18,43 @@ module Kaiser
     def image
       @service_info[:image]
     end
+
+    def command
+      @service_info[:command].to_s
+    end
+
+    def binds
+      @service_info[:binds] || {}
+    end
+
+    def env
+      @service_info[:env] || {}
+    end
+
+    def start_docker_command
+      envstring = env.map do |k,v|
+        "-e #{k}=#{v}"
+      end.join(' ')
+
+      bindstring = binds.map do |k,v|
+        "-v #{k}:#{v}"
+      end.join(' ')
+
+      commandstring = command
+
+      cmd_array = [
+        "docker run -d",
+        "--name #{shared_name}",
+        "--network #{Config.config[:networkname]}",
+        envstring,
+        bindstring,
+        image,
+        commandstring
+      ]
+
+      cmd_array.filter! {|x| !x.empty?}
+
+      cmd_array.join(" ")
+    end
   end
 end

--- a/lib/kaiser/version.rb
+++ b/lib/kaiser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kaiser
-  VERSION = '0.7.1'
+  VERSION = '0.8.0'
 end

--- a/spec/kaiserfile_spec.rb
+++ b/spec/kaiserfile_spec.rb
@@ -198,11 +198,11 @@ RSpec.describe Kaiser::Kaiserfile do
       it 'adds a service' do
         kaiserfile = Kaiser::Kaiserfile.new('Kaiserfile')
         expect(kaiserfile.services).to eq('santaclaus' => {
-          image: 'santaclaus',
-          command: nil,
-          binds: {},
-          env: {}
-        })
+                                            image: 'santaclaus',
+                                            command: nil,
+                                            binds: {},
+                                            env: {}
+                                          })
       end
     end
 
@@ -212,11 +212,11 @@ RSpec.describe Kaiser::Kaiserfile do
       it 'adds a service with the image name' do
         kaiserfile = Kaiser::Kaiserfile.new('Kaiserfile')
         expect(kaiserfile.services).to eq('santaclaus' => {
-          image: 'northpole/santaclaus',
-          command: nil,
-          binds: {},
-          env: {}
-        })
+                                            image: 'northpole/santaclaus',
+                                            command: nil,
+                                            binds: {},
+                                            env: {}
+                                          })
       end
     end
 
@@ -226,11 +226,11 @@ RSpec.describe Kaiser::Kaiserfile do
       it 'adds a service with the image name' do
         kaiserfile = Kaiser::Kaiserfile.new('Kaiserfile')
         expect(kaiserfile.services).to eq('santaclaus' => {
-          image: 'northpole/santaclaus:last_christmas',
-          command: nil,
-          binds: {},
-          env: {}
-        })
+                                            image: 'northpole/santaclaus:last_christmas',
+                                            command: nil,
+                                            binds: {},
+                                            env: {}
+                                          })
       end
     end
   end

--- a/spec/kaiserfile_spec.rb
+++ b/spec/kaiserfile_spec.rb
@@ -197,7 +197,12 @@ RSpec.describe Kaiser::Kaiserfile do
 
       it 'adds a service' do
         kaiserfile = Kaiser::Kaiserfile.new('Kaiserfile')
-        expect(kaiserfile.services).to eq('santaclaus' => { image: 'santaclaus' })
+        expect(kaiserfile.services).to eq('santaclaus' => {
+          image: 'santaclaus',
+          command: nil,
+          binds: {},
+          env: {}
+        })
       end
     end
 
@@ -206,7 +211,12 @@ RSpec.describe Kaiser::Kaiserfile do
 
       it 'adds a service with the image name' do
         kaiserfile = Kaiser::Kaiserfile.new('Kaiserfile')
-        expect(kaiserfile.services).to eq('santaclaus' => { image: 'northpole/santaclaus' })
+        expect(kaiserfile.services).to eq('santaclaus' => {
+          image: 'northpole/santaclaus',
+          command: nil,
+          binds: {},
+          env: {}
+        })
       end
     end
 
@@ -215,7 +225,12 @@ RSpec.describe Kaiser::Kaiserfile do
 
       it 'adds a service with the image name' do
         kaiserfile = Kaiser::Kaiserfile.new('Kaiserfile')
-        expect(kaiserfile.services).to eq('santaclaus' => { image: 'northpole/santaclaus:last_christmas' })
+        expect(kaiserfile.services).to eq('santaclaus' => {
+          image: 'northpole/santaclaus:last_christmas',
+          command: nil,
+          binds: {},
+          env: {}
+        })
       end
     end
   end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -20,4 +20,47 @@ RSpec.describe Kaiser::Service do
 
     expect(s.name).to eq 'santa'
   end
+
+  describe '#start_docker_command' do
+    before do
+      allow(Kaiser::Config).to receive(:config).and_return({ networkname: 'testnet' })
+    end
+
+    it 'provides a proper docker command' do
+      s = Kaiser::Service.new('meow', 'santa', { image: 'np/santa:lol' })
+
+      expect(s.start_docker_command).to eq 'docker run -d --name meow-santa --network testnet np/santa:lol'
+    end
+
+    it 'provides a command with envs' do
+      s = Kaiser::Service.new('meow', 'santa', {
+        image: 'np/santa:lol',
+        env: {
+          "HELLO" => "world"
+        }
+      })
+
+      expect(s.start_docker_command).to eq 'docker run -d --name meow-santa --network testnet -e HELLO=world np/santa:lol'
+    end
+
+    it 'provides a command with binds' do
+      s = Kaiser::Service.new('meow', 'santa', {
+        image: 'np/santa:lol',
+        binds: {
+          "/home/user" => "/home/inside/container"
+        }
+      })
+
+      expect(s.start_docker_command).to eq 'docker run -d --name meow-santa --network testnet -v /home/user:/home/inside/container np/santa:lol'
+    end
+
+    it 'provides a command with command' do
+      s = Kaiser::Service.new('meow', 'santa', {
+        image: 'np/santa:lol',
+        command: 'hohoho'
+      })
+
+      expect(s.start_docker_command).to eq 'docker run -d --name meow-santa --network testnet np/santa:lol hohoho'
+    end
+  end
 end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -34,31 +34,31 @@ RSpec.describe Kaiser::Service do
 
     it 'provides a command with envs' do
       s = Kaiser::Service.new('meow', 'santa', {
-        image: 'np/santa:lol',
-        env: {
-          "HELLO" => "world"
-        }
-      })
+                                image: 'np/santa:lol',
+                                env: {
+                                  'HELLO' => 'world'
+                                }
+                              })
 
       expect(s.start_docker_command).to eq 'docker run -d --name meow-santa --network testnet -e HELLO=world np/santa:lol'
     end
 
     it 'provides a command with binds' do
       s = Kaiser::Service.new('meow', 'santa', {
-        image: 'np/santa:lol',
-        binds: {
-          "/home/user" => "/home/inside/container"
-        }
-      })
+                                image: 'np/santa:lol',
+                                binds: {
+                                  '/home/user' => '/home/inside/container'
+                                }
+                              })
 
       expect(s.start_docker_command).to eq 'docker run -d --name meow-santa --network testnet -v /home/user:/home/inside/container np/santa:lol'
     end
 
     it 'provides a command with command' do
       s = Kaiser::Service.new('meow', 'santa', {
-        image: 'np/santa:lol',
-        command: 'hohoho'
-      })
+                                image: 'np/santa:lol',
+                                command: 'hohoho'
+                              })
 
       expect(s.start_docker_command).to eq 'docker run -d --name meow-santa --network testnet np/santa:lol hohoho'
     end


### PR DESCRIPTION
A way to add auxiliary services that is required by the app in question.

To use you go

```
service 'redis'
```

and then maybe

```
app_params "-e REDIS_URL=redis://<%= envname %>-redis:6347"
```

To connect to it.

Although kaiser sets up a redis already, you might not want some apps to share redis. Also you might want something besides redis. This PR adds this ability.