### PR TITLE
Use a newer image for docker dns due to a python issue

### DIFF
--- a/lib/kaiser/cli.rb
+++ b/lib/kaiser/cli.rb
@@ -583,7 +583,7 @@ module Kaiser
           --network #{Config.config[:networkname]}
           --privileged
           -v /var/run/docker.sock:/docker.sock:ro
-          davidsiaw/docker-dns
+          phensley/docker-dns
           --domain #{http_suffix}
           --record :#{ip_of_container(Config.config[:shared_names][:nginx])}"
       )

--- a/lib/kaiser/version.rb
+++ b/lib/kaiser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kaiser
-  VERSION = '0.8.0'
+  VERSION = '0.8.1'
 end


### PR DESCRIPTION
Use a newer image for docker dns due to a python issue

this was happening

```
2024-06-07T03:02:41.061648 [dockerdns] table.add *.localhost.komoju-dev.tools -> 172.19.0.4
2024-06-07T03:02:41.086430 [dockerdns] table.add kaiser-dns.localhost.komoju-dev.tools -> 172.19.0.6
2024-06-07T03:02:41.089783 [dockerdns] table.add kaiser-nginx.localhost.komoju-dev.tools -> 172.19.0.4
2024-06-07T03:02:41.092423 [dockerdns] table.add kaiser-chrome.localhost.komoju-dev.tools -> 172.19.0.3
2024-06-07T03:02:41.094916 [dockerdns] table.add kaiser-redis.localhost.komoju-dev.tools -> 172.19.0.2
2024-06-07T03:02:41.097654 [dockerdns] table.add redemption-db.localhost.komoju-dev.tools -> 172.19.0.5
2024-06-07T03:02:41.101153 [dockerdns] table.add redemption-dev-1.localhost.komoju-dev.tools -> 172.18.0.3
2024-06-07T03:02:41.101203 [dockerdns] table.add 1.dev.redemption.localhost.komoju-dev.tools -> 172.18.0.3
2024-06-07T03:02:41.101224 [dockerdns] table.add dev.redemption.localhost.komoju-dev.tools -> 172.18.0.3
2024-06-07T03:02:41.104167 [dockerdns] table.add redemption-db-1.localhost.komoju-dev.tools -> 172.18.0.2
2024-06-07T03:02:41.104210 [dockerdns] table.add 1.db.redemption.localhost.komoju-dev.tools -> 172.18.0.2
2024-06-07T03:02:41.104230 [dockerdns] table.add db.redemption.localhost.komoju-dev.tools -> 172.18.0.2
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/gevent/greenlet.py", line 327, in run
    result = self._run(*self.args, **self.kwargs)
  File "./dockerdns", line 161, in run
    evt = json.loads(raw)
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 367, in decode
    raise ValueError(errmsg("Extra data", s, end, len(s)))
ValueError: Extra data: line 2 column 1 - line 3 column 1 (char 313 - 684)
<Greenlet at 0x7ffffe766730: <bound method DockerMonitor.run of <__main__.DockerMonitor object at 0x7fffff2fc910>>> failed with ValueError

Exception KeyError: KeyError(140737468405552,) in <module 'threading' from '/usr/lib/python2.7/threading.pyc'> ignored
```

and it was since fixed by the author and not by my fork